### PR TITLE
Add all of the disk info for child elements

### DIFF
--- a/src/blkinfo/wrappers.py
+++ b/src/blkinfo/wrappers.py
@@ -153,7 +153,7 @@ class LsBlkWrapper(object):
             while parent_stack:
                 p = parent_stack.pop()
                 if p[1] < level:
-                    disk_tree[p[0]]['children'].append(name)
+                    disk_tree[p[0]]['children'].append(disk_tree[name])
                     disk_tree[name]['parents'].append(p[0])
                     parent_stack.append(p)
                     break


### PR DESCRIPTION
I had a problem similar to issue #7 . I wanted to see the mount points for the children. 

My proposed change returns all child data (not just the name) in the disk_tree's 'child' element.

Feel free to ignore as I am using my fork.  Thanks for the project! 💯