### PR TITLE
added exception for KeyError

### DIFF
--- a/src/blkinfo/wrappers.py
+++ b/src/blkinfo/wrappers.py
@@ -153,8 +153,11 @@ class LsBlkWrapper(object):
             while parent_stack:
                 p = parent_stack.pop()
                 if p[1] < level:
-                    disk_tree[p[0]]['children'].append(disk_tree[name])
-                    disk_tree[name]['parents'].append(p[0])
+                    try:
+                        disk_tree[p[0]]['children'].append(disk_tree[name])
+                        disk_tree[name]['parents'].append(p[0])
+                    except KeyError:
+                        continue 
                     parent_stack.append(p)
                     break
 


### PR DESCRIPTION
Hello!

Apparently this module breaks when there're docker volumes present. On one of my hosts I get the following error:

Traceback (most recent call last):
  File "./dpinventory-agent.py", line 89, in <module>
    blkd = BlkDiskInfo()
  File "/usr/local/lib/python3.6/site-packages/blkinfo/wrappers.py", line 58, in __init__
    self._disks = LsBlkWrapper._build_disk_tree()
  File "/usr/local/lib/python3.6/site-packages/blkinfo/wrappers.py", line 156, in _build_disk_tree
    disk_tree[p[0]]['children'].append(disk_tree[name])
KeyError: 'docker-253:4-50749888-ce14c7ed98ed9fa04f3c82e7a22255eae1c606620e805b6612c00e7ae879'

I don't think docker volumes can be regarded as actual blk devices so simply skipping them seems reasonable to me.