### PR TITLE
Add option to ignore raid parents

### DIFF
--- a/src/blkinfo/filters.py
+++ b/src/blkinfo/filters.py
@@ -13,7 +13,7 @@ class BlkDiskInfo(LsBlkWrapper):
         disks available in the system and different parameters related to block devices
     """
 
-    def get_disks(self, filters=None):
+    def get_disks(self, filters=None, ignore_raid_parents=True):
         """method returns all disks available in the system, after applying filters"""
 
         result = []
@@ -35,14 +35,13 @@ class BlkDiskInfo(LsBlkWrapper):
 
                 # if raid is assembled with parents w/o partitions
                 # we should show only raid and ignore all parents
-                ignore_parents = False
 
                 for p in self._disks[dn]['parents']:
                     if len(self._disks[p]['children']) != 1:
-                        ignore_parents = False
+                        ignore_raid_parents = False
                         break
 
-                if ignore_parents:
+                if ignore_raid_parents:
                     for p in self._disks[dn]['parents']:
                         blacklist.add(p)
 

--- a/src/blkinfo/filters.py
+++ b/src/blkinfo/filters.py
@@ -35,7 +35,7 @@ class BlkDiskInfo(LsBlkWrapper):
 
                 # if raid is assembled with parents w/o partitions
                 # we should show only raid and ignore all parents
-                ignore_parents = True
+                ignore_parents = False
 
                 for p in self._disks[dn]['parents']:
                     if len(self._disks[p]['children']) != 1:


### PR DESCRIPTION
Raid parents are ignored by default.
This PR adds an argument to get_disks in filters.py to enable/disable it.